### PR TITLE
docs: callout using the CAR CID in the store request not the DAG root CID

### DIFF
--- a/src/pages/docs/how-to/http-bridge.mdx
+++ b/src/pages/docs/how-to/http-bridge.mdx
@@ -164,6 +164,10 @@ in it, replacing `did:key:z6Mkabc123` with the space you used to generate auth h
   ]
 }
 ```
+<Callout type="info">
+**Important:** Make sure you use the CID from the output of `ipfs-car hash <file>` as the `link` in the file above!
+It should start with `bag...`. It is _not_ the same as the DAG root CID (which usually starts `bafy...`).
+</Callout>
 
 Finally, run `curl` replacing the values of the `X-Auth-Secret` and `Authorization`
 headers with the values you generated above:


### PR DESCRIPTION
Just makes the docs a bit more explicit that the CID to use in the store request is the CID of the CAR shard, not the CID of the DAG root.